### PR TITLE
fix: correct gradient CF corruption in format_background_gradient

### DIFF
--- a/src/pbi_cli/core/format_backend.py
+++ b/src/pbi_cli/core/format_backend.py
@@ -54,8 +54,15 @@ def _save_visual(
     visual_name: str,
     data: dict[str, Any],
 ) -> None:
-    """Write visual JSON data back to disk."""
+    """Write visual JSON data back to disk.
+
+    A ``.json.bak`` copy of the previous file is created before writing so
+    that a corrupted write can be recovered manually.
+    """
     visual_path = get_visual_dir(definition_path, page_name, visual_name) / "visual.json"
+    if visual_path.exists():
+        backup_path = visual_path.with_suffix(".json.bak")
+        backup_path.write_bytes(visual_path.read_bytes())
     _write_json(visual_path, data)
 
 
@@ -132,8 +139,8 @@ def format_background_gradient(
     input_table: str,
     input_column: str,
     field_query_ref: str,
-    min_color: str = "minColor",
-    max_color: str = "maxColor",
+    min_color: str = "#FFFFFF",
+    max_color: str = "#118DFF",
 ) -> dict[str, Any]:
     """Add a linear gradient background color rule to a visual column.
 
@@ -176,11 +183,13 @@ def format_background_gradient(
                                 },
                                 "FillRule": {
                                     "linearGradient2": {
-                                        "min": {"color": {"Literal": {"Value": f"'{min_color}'"}}},
-                                        "max": {"color": {"Literal": {"Value": f"'{max_color}'"}}},
-                                        "nullColoringStrategy": {
-                                            "strategy": {"Literal": {"Value": "'asZero'"}}
+                                        "min": {
+                                            "color": {"Literal": {"Value": f"'{min_color}'"}},
+                                            "nullColoringStrategy": {
+                                                "strategy": {"Literal": {"Value": "'asZero'"}}
+                                            },
                                         },
+                                        "max": {"color": {"Literal": {"Value": f"'{max_color}'"}}},
                                     }
                                 },
                             }


### PR DESCRIPTION
## Summary

- **`nullColoringStrategy` moved inside `min` stop** — it was placed as a sibling of `min`/`max` at the `linearGradient2` level. Power BI expects it nested inside the `min` object. Desktop silently \"corrects\" the misplaced key on save, wiping the entire gradient conditional format.
- **Default colors changed from invalid strings to real hex values** — `min_color=\"minColor\"` and `max_color=\"maxColor\"` produced literal strings that Power BI cannot interpret as colors. Replaced with `\"#FFFFFF\"` / `\"#118DFF\"` (white → standard PBI blue), matching Power BI Desktop's own default gradient.
- **Pre-write backup added to `_save_visual()`** — writes `visual.json.bak` before every overwrite so a bad write can be recovered by renaming the backup.

## Root cause detail

```json
// BEFORE — nullColoringStrategy at wrong level (linearGradient2 sibling)
"linearGradient2": {
    "min": {"color": {"Literal": {"Value": "'minColor'"}}},
    "max": {"color": {"Literal": {"Value": "'maxColor'"}}},
    "nullColoringStrategy": {"strategy": {"Literal": {"Value": "'asZero'"}}}
}

// AFTER — nullColoringStrategy inside min, valid hex defaults
"linearGradient2": {
    "min": {
        "color": {"Literal": {"Value": "'#FFFFFF'"}},
        "nullColoringStrategy": {"strategy": {"Literal": {"Value": "'asZero'"}}}
    },
    "max": {"color": {"Literal": {"Value": "'#118DFF'"}}}
}
```

## Test plan

- [ ] Apply a gradient CF to a table column with `pbi format background-gradient`
- [ ] Open the report in Power BI Desktop — gradient should render
- [ ] Save in Desktop — gradient should **persist** after save (this was the failure mode)
- [ ] Confirm `visual.json.bak` is created alongside `visual.json` after any format command

🤖 Generated with [Claude Code](https://claude.com/claude-code)