### PR TITLE
feat: add custom visual authoring (vibe-code .pbiviz)

### DIFF
--- a/.github/workflows/custom-visual-smoke.yml
+++ b/.github/workflows/custom-visual-smoke.yml
@@ -1,0 +1,84 @@
+name: Custom Visual SDK Smoke
+
+# Catches drift in the pinned powerbi-visuals-tools / powerbi-visuals-api
+# versions without paying the cost on every PR. The matching crib lives in
+# src/pbi_cli/skills/power-bi-custom-visuals/AGENTS-template.md -- when this
+# job breaks, bump both versions and update the crib together.
+
+on:
+  schedule:
+    - cron: "17 5 * * *"  # nightly
+  push:
+    branches: [master]
+    paths:
+      - "src/pbi_cli/skills/power-bi-custom-visuals/**"
+      - "src/pbi_cli/core/custom_visual_backend.py"
+      - ".github/workflows/custom-visual-smoke.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "src/pbi_cli/skills/power-bi-custom-visuals/**"
+      - "src/pbi_cli/core/custom_visual_backend.py"
+      - ".github/workflows/custom-visual-smoke.yml"
+  workflow_dispatch:
+
+jobs:
+  pbiviz-end-to-end:
+    runs-on: windows-latest
+    timeout-minutes: 10
+    env:
+      PBIVIZ_VERSION: "^5.6.0"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install pbi-cli
+        run: pip install -e ".[dev]"
+
+      - name: Scaffold a custom visual
+        shell: bash
+        run: |
+          mkdir -p smoke
+          cd smoke
+          npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" new smoke-visual
+
+      - name: Type-check the scaffold
+        shell: bash
+        working-directory: smoke/smoke-visual
+        run: |
+          npm install --no-audit --no-fund
+          npx tsc --noEmit -p tsconfig.json
+
+      - name: Package the scaffold
+        shell: bash
+        working-directory: smoke/smoke-visual
+        run: npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" package
+
+      - name: Verify .pbiviz produced
+        shell: bash
+        working-directory: smoke/smoke-visual
+        run: |
+          ls dist/*.pbiviz
+          test -s dist/*.pbiviz
+
+      - name: Round-trip through pbi-cli import
+        shell: bash
+        run: |
+          # Build a tiny PBIR target
+          mkdir -p smoke/Demo.Report/definition
+          cat > smoke/Demo.Report/definition/report.json <<'JSON'
+          {
+            "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/1.0.0/schema.json",
+            "layoutOptimization": "Disabled"
+          }
+          JSON
+          PBIVIZ=$(ls smoke/smoke-visual/dist/*.pbiviz | head -n1)
+          pbi visual --path smoke/Demo.Report --no-sync import-custom "${PBIVIZ}"
+          pbi visual --path smoke/Demo.Report --no-sync list-custom

--- a/.github/workflows/custom-visual-smoke.yml
+++ b/.github/workflows/custom-visual-smoke.yml
@@ -47,23 +47,23 @@ jobs:
         run: |
           mkdir -p smoke
           cd smoke
-          npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" new smoke-visual
+          npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" new smokevisual
 
       - name: Type-check the scaffold
         shell: bash
-        working-directory: smoke/smoke-visual
+        working-directory: smoke/smokevisual
         run: |
           npm install --no-audit --no-fund
           npx tsc --noEmit -p tsconfig.json
 
       - name: Package the scaffold
         shell: bash
-        working-directory: smoke/smoke-visual
+        working-directory: smoke/smokevisual
         run: npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" package
 
       - name: Verify .pbiviz produced
         shell: bash
-        working-directory: smoke/smoke-visual
+        working-directory: smoke/smokevisual
         run: |
           ls dist/*.pbiviz
           test -s dist/*.pbiviz
@@ -79,6 +79,6 @@ jobs:
             "layoutOptimization": "Disabled"
           }
           JSON
-          PBIVIZ=$(ls smoke/smoke-visual/dist/*.pbiviz | head -n1)
+          PBIVIZ=$(ls smoke/smokevisual/dist/*.pbiviz | head -n1)
           pbi visual --path smoke/Demo.Report --no-sync import-custom "${PBIVIZ}"
           pbi visual --path smoke/Demo.Report --no-sync list-custom

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Custom visual authoring** -- vibe-code Power BI custom visuals end-to-end with the new `power-bi-custom-visuals` Claude skill. The skill scaffolds a TypeScript project sibling to your `.pbip` via `npx pbiviz new`, iterates against the Power BI Visuals SDK with `tsc --noEmit` between every change, packages a `.pbiviz`, and embeds it into the report. Auto-installs Node and `pbiviz` (with consent), pins SDK to a known-good version, runs an npm allowlist for common deps. Inner loop is agent-driven on TypeScript errors; visual correctness is checked once with the user at the end.
+- `pbi visual import-custom <pbiviz>` -- copy a locally-built `.pbiviz` into `StaticResources/RegisteredResources/` and register it in `report.json`. `--replace` overwrites by GUID for the iteration loop.
+- `pbi visual list-custom` -- list embedded and public custom visuals with a `kind` distinguisher.
+- `pbi visual remove-custom <guid-or-name>` -- deregister and physically delete the `.pbiviz`.
+
 ## [3.10.6] - 2026-04-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.11.0] - 2026-05-03
 
 ### Added
 - **Custom visual authoring** -- vibe-code Power BI custom visuals end-to-end with the new `power-bi-custom-visuals` Claude skill. The skill scaffolds a TypeScript project sibling to your `.pbip` via `npx pbiviz new`, iterates against the Power BI Visuals SDK with `tsc --noEmit` between every change, packages a `.pbiviz`, and embeds it into the report. Auto-installs Node and `pbiviz` (with consent), pins SDK to a known-good version, runs an npm allowlist for common deps. Inner loop is agent-driven on TypeScript errors; visual correctness is checked once with the user at the end.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Bundled DLLs ship inside the Python package (`pbi_cli/dlls/`).
 
 ## Skills
 
-After running `pbi-cli skills install`, Claude Code discovers **12 Power BI skills**. Each skill teaches Claude a different area. You don't need to memorize commands.
+After running `pbi-cli skills install`, Claude Code discovers **13 Power BI skills**. Each skill teaches Claude a different area. You don't need to memorize commands.
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/MinaSaad1/pbi-cli/master/assets/skills-hub.svg" alt="12 Skills" width="850"/>
@@ -227,6 +227,40 @@ After running `pbi-cli skills install`, Claude Code discovers **12 Power BI skil
 | **Pages** | *"Add an Executive Overview page"* | Manages pages, bookmarks, visibility, drillthrough |
 | **Themes** | *"Apply our corporate brand colours"* | Applies themes, conditional formatting, colour scales |
 | **Filters** | *"Show only the top 10 products"* | Adds page/visual filters (TopN, date, categorical) |
+| **Custom Visuals** | *"Build a radial gauge Power BI doesn't have"* | Scaffolds a TypeScript visual project, iterates on `tsc --noEmit`, packages `.pbiviz`, imports into the report |
+
+---
+
+## Custom Visual Authoring
+
+The **Custom Visuals** skill turns vibe-coding into the Power BI Visuals SDK loop.
+Claude scaffolds a sibling TypeScript project with `npx pbiviz new`, iterates against
+the Power BI Visuals API with `tsc --noEmit` between every change, packages a
+`.pbiviz`, and embeds it into your report:
+
+```bash
+# After installing the skill, just describe what you want in Claude Code:
+#   "Build me a radial gauge that highlights values above target"
+#
+# Under the hood, the skill drives:
+npx --yes powerbi-visuals-tools@^5.6.0 new my-gauge-visual
+# (Claude edits src/visual.ts + capabilities.json, runs tsc --noEmit until clean)
+npx --yes powerbi-visuals-tools@^5.6.0 package
+pbi visual import-custom dist/my-gauge-visual.1.0.5.pbiviz --replace
+```
+
+The skill auto-installs Node and `pbiviz` on first run (with your consent), pins
+the SDK to a known-good version, keeps the TypeScript project as a sibling to your
+`.pbip` (no PBIR contamination), and operates under a curated npm allowlist for
+common deps (D3, Lodash, date-fns) -- anything off-list requires explicit approval.
+
+Three new pbi-cli commands support the loop:
+
+| Command | What it does |
+|---------|-------------|
+| `pbi visual import-custom <pbiviz>` | Embed a locally-built `.pbiviz` into the report's `RegisteredResources/` and register it in `report.json`. `--replace` overwrites by GUID. |
+| `pbi visual list-custom` | List embedded and public (AppSource) custom visuals, distinguished by `kind`. |
+| `pbi visual remove-custom <guid-or-name>` | Deregister and physically delete the `.pbiviz` resource. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -243,10 +243,10 @@ the Power BI Visuals API with `tsc --noEmit` between every change, packages a
 #   "Build me a radial gauge that highlights values above target"
 #
 # Under the hood, the skill drives:
-npx --yes powerbi-visuals-tools@^5.6.0 new my-gauge-visual
+npx --yes powerbi-visuals-tools@^5.6.0 new mygaugevisual
 # (Claude edits src/visual.ts + capabilities.json, runs tsc --noEmit until clean)
 npx --yes powerbi-visuals-tools@^5.6.0 package
-pbi visual import-custom dist/my-gauge-visual.1.0.5.pbiviz --replace
+pbi visual import-custom dist/mygaugevisual.1.0.5.pbiviz --replace
 ```
 
 The skill auto-installs Node and `pbiviz` on first run (with your consent), pins

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbi-cli-tool"
-version = "3.10.10"
+version = "3.11.0"
 description = "CLI for Power BI semantic models and PBIR reports - direct .NET connection for token-efficient AI agent usage"
 readme = "README.pypi.md"
 license = "MIT AND LicenseRef-Microsoft-AS-Client-Libraries"

--- a/src/pbi_cli/commands/visual.py
+++ b/src/pbi_cli/commands/visual.py
@@ -658,3 +658,103 @@ def calc_delete(
         visual_name=visual_name,
         calc_name=calc_name,
     )
+
+
+# ---------------------------------------------------------------------------
+# Custom visual commands (locally-built .pbiviz embedding)
+# ---------------------------------------------------------------------------
+
+
+@visual.command(name="import-custom")
+@click.argument("pbiviz_file", type=click.Path(exists=True, dir_okay=False))
+@click.option(
+    "--replace",
+    is_flag=True,
+    default=False,
+    help="Overwrite an existing custom visual with the same GUID.",
+)
+@click.pass_context
+@pass_context
+def import_custom(
+    ctx: PbiContext,
+    click_ctx: click.Context,
+    pbiviz_file: str,
+    replace: bool,
+) -> None:
+    """Import a locally-built .pbiviz into the report.
+
+    Copies the file to ``StaticResources/RegisteredResources/`` and
+    registers it in ``report.json``. Sanity-checks the archive and
+    manifest; deep validation is left to ``pbiviz package`` and Power BI
+    Desktop's loader.
+
+    The GUID is read from the archive's ``package.json``. Pass
+    ``--replace`` to overwrite an existing entry with the same GUID
+    (typical during the vibe-coding iteration loop).
+    """
+    from pathlib import Path
+
+    from pbi_cli.core.custom_visual_backend import custom_visual_import
+    from pbi_cli.core.pbir_path import resolve_report_path
+
+    definition_path = resolve_report_path(_get_report_path(click_ctx))
+    run_command(
+        ctx,
+        custom_visual_import,
+        definition_path=definition_path,
+        pbiviz_path=Path(pbiviz_file),
+        replace=replace,
+    )
+
+
+@visual.command(name="list-custom")
+@click.pass_context
+@pass_context
+def list_custom(ctx: PbiContext, click_ctx: click.Context) -> None:
+    """List custom visuals registered in the report.
+
+    Shows both embedded (locally-built ``.pbiviz``) and public
+    (AppSource / organizational) custom visuals with a ``kind``
+    distinguisher.
+    """
+    from pbi_cli.core.custom_visual_backend import custom_visual_list
+    from pbi_cli.core.pbir_path import resolve_report_path
+
+    definition_path = resolve_report_path(_get_report_path(click_ctx))
+    run_command(
+        ctx,
+        custom_visual_list,
+        definition_path=definition_path,
+    )
+
+
+@visual.command(name="remove-custom")
+@click.argument("identifier")
+@click.pass_context
+@pass_context
+def remove_custom(
+    ctx: PbiContext,
+    click_ctx: click.Context,
+    identifier: str,
+) -> None:
+    """Remove an embedded custom visual by GUID or name.
+
+    GUID is canonical and unambiguous. Name lookup matches the
+    ``<safe-name>`` portion of the registered filename; if the name
+    matches multiple visuals, the command errors and asks you to
+    disambiguate by GUID. The ``.pbiviz`` resource file is deleted from
+    ``StaticResources/RegisteredResources/`` along with its registration.
+
+    Public (AppSource) entries are out of scope; remove those from
+    ``report.json`` directly or via Power BI Desktop.
+    """
+    from pbi_cli.core.custom_visual_backend import custom_visual_remove
+    from pbi_cli.core.pbir_path import resolve_report_path
+
+    definition_path = resolve_report_path(_get_report_path(click_ctx))
+    run_command(
+        ctx,
+        custom_visual_remove,
+        definition_path=definition_path,
+        identifier=identifier,
+    )

--- a/src/pbi_cli/core/claude_integration.py
+++ b/src/pbi_cli/core/claude_integration.py
@@ -34,6 +34,8 @@ _PBI_CLI_CLAUDE_MD_SNIPPET = (
     "- **power-bi-pages** -- pages, bookmarks, visibility, drillthrough\n"
     "- **power-bi-themes** -- themes, conditional formatting, styling\n"
     "- **power-bi-filters** -- page and visual filters (TopN, date, categorical)\n"
+    "- **power-bi-custom-visuals** -- vibe-code .pbiviz custom visuals "
+    "(TS scaffold, tsc loop, package, import)\n"
     "\n"
     "Critical: Multi-line DAX (VAR/RETURN) cannot be passed via `-e`.\n"
     "Use `--file` or stdin piping instead. See power-bi-dax skill.\n"

--- a/src/pbi_cli/core/custom_visual_backend.py
+++ b/src/pbi_cli/core/custom_visual_backend.py
@@ -1,0 +1,476 @@
+"""Custom visual operations for PBIR reports.
+
+Embedded ``.pbiviz`` packages are placed in
+``<.Report>/StaticResources/RegisteredResources/`` and registered in
+``definition/report.json`` so that Power BI Desktop loads them on open.
+
+Public (AppSource / organizational) visuals are referenced by GUID only via
+``publicCustomVisuals`` and have no embedded resource.
+
+Scope is locally-built ``.pbiviz`` files (the vibe-coding output path).
+AppSource registration is intentionally out of scope; ``list-custom`` reads
+``publicCustomVisuals`` for completeness but ``import-custom`` and
+``remove-custom`` only operate on embedded resources.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import zipfile
+from pathlib import Path
+from typing import Any
+
+from pbi_cli.core.errors import PbiCliError
+
+# Resource type code used for custom visuals in PBIR ``resourcePackages`` items.
+# Mirrors the legacy PBIX resource enum where 5 == CustomVisual.
+_CUSTOM_VISUAL_RESOURCE_TYPE = 5
+
+# Subpath used in the ``path`` field of resource items (logical scope, not
+# a real subfolder; physical file lives directly under RegisteredResources).
+_CUSTOM_VISUAL_PATH_SCOPE = "CustomVisuals"
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    result: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    return result
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# .pbiviz package inspection
+# ---------------------------------------------------------------------------
+
+
+def _read_pbiviz_manifest(pbiviz_path: Path) -> dict[str, Any]:
+    """Open a .pbiviz archive and return the parsed package.json visual block.
+
+    Sanity checks only: archive opens, package.json present and parseable,
+    visual.guid and visual.version are non-empty strings. Deep validation
+    (capabilities schema, API compatibility) is left to ``pbiviz package``
+    and Power BI Desktop's loader.
+    """
+    if not pbiviz_path.exists():
+        raise PbiCliError(f".pbiviz file not found: {pbiviz_path}")
+    if not pbiviz_path.is_file():
+        raise PbiCliError(f".pbiviz path is not a file: {pbiviz_path}")
+
+    try:
+        with zipfile.ZipFile(pbiviz_path, "r") as zf:
+            try:
+                manifest_bytes = zf.read("package.json")
+            except KeyError as exc:
+                raise PbiCliError(
+                    f"Invalid .pbiviz: package.json not found inside {pbiviz_path.name}"
+                ) from exc
+    except zipfile.BadZipFile as exc:
+        raise PbiCliError(f"Invalid .pbiviz: not a valid zip archive ({pbiviz_path.name})") from exc
+
+    try:
+        manifest = json.loads(manifest_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise PbiCliError(
+            f"Invalid .pbiviz: package.json is not valid JSON ({pbiviz_path.name})"
+        ) from exc
+
+    visual = manifest.get("visual")
+    if not isinstance(visual, dict):
+        raise PbiCliError(
+            "Invalid .pbiviz: package.json missing 'visual' object "
+            "(expected fields: guid, name, version, apiVersion)"
+        )
+
+    guid = visual.get("guid")
+    version = visual.get("version")
+    name = visual.get("name") or visual.get("displayName")
+
+    if not isinstance(guid, str) or not guid.strip():
+        raise PbiCliError("Invalid .pbiviz: visual.guid missing or empty")
+    if not isinstance(version, str) or not version.strip():
+        raise PbiCliError("Invalid .pbiviz: visual.version missing or empty")
+    if not isinstance(name, str) or not name.strip():
+        raise PbiCliError("Invalid .pbiviz: visual.name (or displayName) missing or empty")
+
+    return {
+        "guid": guid.strip(),
+        "name": name.strip(),
+        "version": version.strip(),
+        "display_name": (visual.get("displayName") or name).strip(),
+        "api_version": str(visual.get("apiVersion") or "").strip(),
+    }
+
+
+def _resource_filename(manifest: dict[str, Any]) -> str:
+    """Build the on-disk filename for a custom visual resource.
+
+    Uses ``<sanitized-name>.<guid>.pbiviz`` to avoid collisions when two
+    visuals happen to share a friendly name.
+    """
+    safe_name = re.sub(r"[^A-Za-z0-9_-]+", "_", manifest["name"]).strip("_") or "visual"
+    return f"{safe_name}.{manifest['guid']}.pbiviz"
+
+
+# ---------------------------------------------------------------------------
+# report.json mutation
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create_resource_package(report_data: dict[str, Any]) -> dict[str, Any]:
+    """Ensure a RegisteredResources package exists and return it."""
+    packages = report_data.setdefault("resourcePackages", [])
+    for pkg in packages:
+        if pkg.get("name") == "RegisteredResources":
+            pkg.setdefault("items", [])
+            return pkg  # type: ignore[no-any-return]
+
+    pkg = {
+        "name": "RegisteredResources",
+        "type": "RegisteredResources",
+        "items": [],
+    }
+    packages.append(pkg)
+    return pkg
+
+
+def _find_embedded_entry(report_data: dict[str, Any], guid: str) -> dict[str, Any] | None:
+    """Return the customVisuals entry matching the given GUID, or None."""
+    for entry in report_data.get("customVisuals", []) or []:
+        if isinstance(entry, dict) and entry.get("name") == guid:
+            return entry
+    return None
+
+
+def _remove_embedded_registration(
+    report_data: dict[str, Any], guid: str, filename: str | None
+) -> bool:
+    """Remove a custom visual's entries from report.json.
+
+    Returns True if anything was removed.
+    """
+    removed = False
+
+    custom_visuals = report_data.get("customVisuals")
+    if isinstance(custom_visuals, list):
+        new_list = [
+            e for e in custom_visuals if not (isinstance(e, dict) and e.get("name") == guid)
+        ]
+        if len(new_list) != len(custom_visuals):
+            report_data["customVisuals"] = new_list
+            removed = True
+
+    if filename is not None:
+        for pkg in report_data.get("resourcePackages", []) or []:
+            if pkg.get("name") != "RegisteredResources":
+                continue
+            items = pkg.get("items")
+            if not isinstance(items, list):
+                continue
+            new_items = [i for i in items if i.get("name") != filename]
+            if len(new_items) != len(items):
+                pkg["items"] = new_items
+                removed = True
+
+    return removed
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def custom_visual_import(
+    definition_path: Path,
+    pbiviz_path: Path,
+    replace: bool = False,
+) -> dict[str, Any]:
+    """Register a locally-built .pbiviz into a PBIR report.
+
+    Validates the zip + manifest, copies the file to
+    ``StaticResources/RegisteredResources/``, and updates ``report.json``
+    so Desktop loads it on open.
+
+    Returns ``{status, guid, name, version, file}``. Status is ``"added"``
+    on first import or when ``replace=True`` overwrites an existing entry.
+    """
+    manifest = _read_pbiviz_manifest(pbiviz_path)
+    guid = manifest["guid"]
+
+    report_json_path = definition_path / "report.json"
+    if not report_json_path.exists():
+        raise PbiCliError("report.json not found -- is this a valid PBIR definition folder?")
+    report_data = _read_json(report_json_path)
+
+    existing = _find_embedded_entry(report_data, guid)
+    if existing is not None and not replace:
+        raise PbiCliError(
+            f"Custom visual already registered (guid={guid}, version="
+            f"{existing.get('version')!r}). Pass --replace to overwrite."
+        )
+
+    filename = _resource_filename(manifest)
+    report_folder = definition_path.parent
+    resources_dir = report_folder / "StaticResources" / "RegisteredResources"
+    resources_dir.mkdir(parents=True, exist_ok=True)
+    dest = resources_dir / filename
+
+    if existing is not None:
+        # Best-effort cleanup of any prior on-disk file with this GUID.
+        for old in resources_dir.glob(f"*.{guid}.pbiviz"):
+            try:
+                old.unlink()
+            except OSError:
+                pass
+        _remove_embedded_registration(report_data, guid, filename=None)
+
+    dest.write_bytes(pbiviz_path.read_bytes())
+
+    pkg = _get_or_create_resource_package(report_data)
+    pkg_items: list[dict[str, Any]] = pkg["items"]
+    # Drop any stale item with same filename, then append fresh.
+    pkg["items"] = [i for i in pkg_items if i.get("name") != filename]
+    pkg["items"].append(
+        {
+            "name": filename,
+            "type": _CUSTOM_VISUAL_RESOURCE_TYPE,
+            "path": f"{_CUSTOM_VISUAL_PATH_SCOPE}/{filename}",
+        }
+    )
+
+    custom_visuals = report_data.setdefault("customVisuals", [])
+    custom_visuals.append({"name": guid, "version": manifest["version"]})
+
+    _write_json(report_json_path, report_data)
+
+    return {
+        "status": "added",
+        "guid": guid,
+        "name": manifest["name"],
+        "version": manifest["version"],
+        "file": str(dest),
+        "replaced": existing is not None,
+    }
+
+
+def custom_visual_list(definition_path: Path) -> dict[str, Any]:
+    """List custom visuals registered in a PBIR report.
+
+    Returns ``{embedded: [...], public: [...]}`` where each item carries
+    a ``kind`` field. Embedded entries include the on-disk file path when
+    present; public entries are GUID-only AppSource/org references.
+    """
+    report_json_path = definition_path / "report.json"
+    if not report_json_path.exists():
+        raise PbiCliError("report.json not found -- is this a valid PBIR definition folder?")
+    report_data = _read_json(report_json_path)
+
+    report_folder = definition_path.parent
+    resources_dir = report_folder / "StaticResources" / "RegisteredResources"
+
+    # Build a guid -> filename map from the resource package, if any
+    guid_to_file: dict[str, str] = {}
+    for pkg in report_data.get("resourcePackages", []) or []:
+        if pkg.get("name") != "RegisteredResources":
+            continue
+        for item in pkg.get("items", []) or []:
+            if item.get("type") != _CUSTOM_VISUAL_RESOURCE_TYPE:
+                continue
+            name = item.get("name")
+            if not isinstance(name, str):
+                continue
+            # Filename pattern: <safe>.<guid>.pbiviz
+            m = re.match(r"^.+\.([0-9A-Za-z_-]+)\.pbiviz$", name)
+            if m:
+                guid_to_file[m.group(1)] = name
+
+    embedded: list[dict[str, Any]] = []
+    for entry in report_data.get("customVisuals", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        guid = entry.get("name")
+        if not isinstance(guid, str):
+            continue
+        filename = guid_to_file.get(guid)
+        file_path = (
+            str(resources_dir / filename)
+            if filename and (resources_dir / filename).exists()
+            else None
+        )
+        embedded.append(
+            {
+                "kind": "embedded",
+                "guid": guid,
+                "version": entry.get("version"),
+                "file": file_path,
+            }
+        )
+
+    public: list[dict[str, Any]] = []
+    for guid in report_data.get("publicCustomVisuals", []) or []:
+        if isinstance(guid, str):
+            public.append({"kind": "public", "guid": guid})
+
+    return {
+        "embedded": embedded,
+        "public": public,
+        "total": len(embedded) + len(public),
+    }
+
+
+def custom_visual_remove(
+    definition_path: Path,
+    identifier: str,
+) -> dict[str, Any]:
+    """Remove an embedded custom visual by GUID or friendly name.
+
+    Friendly-name lookup is best-effort against the on-disk filename
+    pattern ``<safe-name>.<guid>.pbiviz``. If ambiguous, raises with
+    guidance to disambiguate by GUID.
+
+    Public (AppSource) visuals registered via ``publicCustomVisuals`` are
+    out of scope here -- a separate ``register-public`` / ``unregister-public``
+    surface is intentionally deferred.
+    """
+    if not identifier or not identifier.strip():
+        raise PbiCliError("Identifier (GUID or name) is required.")
+    identifier = identifier.strip()
+
+    report_json_path = definition_path / "report.json"
+    if not report_json_path.exists():
+        raise PbiCliError("report.json not found -- is this a valid PBIR definition folder?")
+    report_data = _read_json(report_json_path)
+
+    report_folder = definition_path.parent
+    resources_dir = report_folder / "StaticResources" / "RegisteredResources"
+
+    # Build candidate map: guid -> filename
+    guid_to_file: dict[str, str] = {}
+    for pkg in report_data.get("resourcePackages", []) or []:
+        if pkg.get("name") != "RegisteredResources":
+            continue
+        for item in pkg.get("items", []) or []:
+            if item.get("type") != _CUSTOM_VISUAL_RESOURCE_TYPE:
+                continue
+            name = item.get("name")
+            if not isinstance(name, str):
+                continue
+            m = re.match(r"^(.+)\.([0-9A-Za-z_-]+)\.pbiviz$", name)
+            if m:
+                guid_to_file[m.group(2)] = name
+
+    target_guid: str | None = None
+
+    # Direct GUID match against customVisuals
+    for entry in report_data.get("customVisuals", []) or []:
+        if isinstance(entry, dict) and entry.get("name") == identifier:
+            target_guid = identifier
+            break
+
+    if target_guid is None:
+        # Try name-based lookup via the filename pattern
+        matches: list[str] = []
+        for guid, fname in guid_to_file.items():
+            m = re.match(r"^(.+)\.([0-9A-Za-z_-]+)\.pbiviz$", fname)
+            if not m:
+                continue
+            safe_name = m.group(1)
+            if safe_name == identifier or safe_name.lower() == identifier.lower():
+                matches.append(guid)
+        if len(matches) > 1:
+            raise PbiCliError(
+                f"Name {identifier!r} matches {len(matches)} custom visuals "
+                f"({', '.join(matches)}). Disambiguate by passing the GUID."
+            )
+        if len(matches) == 1:
+            target_guid = matches[0]
+
+    if target_guid is None:
+        raise PbiCliError(
+            f"No embedded custom visual found for identifier {identifier!r}. "
+            "Use `pbi visual list-custom` to see what's registered."
+        )
+
+    filename: str | None = guid_to_file.get(target_guid)
+    removed = _remove_embedded_registration(report_data, target_guid, filename)
+    if not removed:
+        raise PbiCliError(f"Custom visual {target_guid!r} not found in report.json registration.")
+
+    file_deleted = False
+    if filename is not None:
+        candidate = resources_dir / filename
+        if candidate.exists():
+            try:
+                candidate.unlink()
+                file_deleted = True
+            except OSError as exc:
+                raise PbiCliError(f"Failed to delete {candidate}: {exc}") from exc
+
+    _write_json(report_json_path, report_data)
+
+    return {
+        "status": "removed",
+        "guid": target_guid,
+        "file_deleted": file_deleted,
+        "file": str(resources_dir / filename) if filename else None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# pbiviz.json version auto-bump (skill helper)
+# ---------------------------------------------------------------------------
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
+def pbiviz_bump_patch(pbiviz_json_path: Path) -> dict[str, Any]:
+    """Increment the patch version in a custom visual project's pbiviz.json.
+
+    Used by the ``power-bi-custom-visuals`` skill between iterations so
+    Power BI Desktop's GUID+version cache invalidates and serves fresh
+    code on each repackage.
+
+    If the current version doesn't match ``<int>.<int>.<int>``, treat as a
+    user-managed override and skip without raising. Returns the chosen
+    behavior so the skill can surface it to the user.
+    """
+    if not pbiviz_json_path.exists():
+        raise PbiCliError(f"pbiviz.json not found: {pbiviz_json_path}")
+
+    data = _read_json(pbiviz_json_path)
+    visual = data.get("visual")
+    if not isinstance(visual, dict):
+        raise PbiCliError("pbiviz.json: missing 'visual' block")
+
+    current = visual.get("version")
+    if not isinstance(current, str):
+        raise PbiCliError("pbiviz.json: visual.version is missing")
+
+    m = _SEMVER_RE.match(current.strip())
+    if m is None:
+        return {
+            "status": "skipped",
+            "reason": "version does not match major.minor.patch; treating as user override",
+            "version": current,
+        }
+
+    major, minor, patch = (int(g) for g in m.groups())
+    new_version = f"{major}.{minor}.{patch + 1}"
+    visual["version"] = new_version
+    _write_json(pbiviz_json_path, data)
+
+    return {
+        "status": "bumped",
+        "previous": current,
+        "version": new_version,
+    }

--- a/src/pbi_cli/skills/power-bi-custom-visuals/AGENTS-template.md
+++ b/src/pbi_cli/skills/power-bi-custom-visuals/AGENTS-template.md
@@ -1,0 +1,130 @@
+# AGENTS.md — Custom Visual Project Guide
+
+This file is for AI agents iterating on this Power BI custom visual.
+The `power-bi-custom-visuals` skill (from pbi-cli) drops it in on
+scaffold. Keep it. Update it as the project evolves.
+
+## Editable vs locked files
+
+✅ **Editable freely:**
+
+- `src/visual.ts` — the `IVisual` implementation. Render logic lives here.
+- `src/settings.ts` — formatting model definitions (right-pane controls).
+- `capabilities.json` — data roles, dataViewMappings, objects (formatting
+  property declarations).
+- `style/visual.less` — visual-scoped CSS.
+- `assets/icon.png` — visual icon (replace, don't rename).
+
+🔒 **Don't touch without surfacing to the user first:**
+
+- `tsconfig.json` — TypeScript compiler config.
+- `pbiviz.json` — visual metadata (the skill auto-bumps `version` here;
+  don't edit `version` manually unless you mean to override the
+  auto-bump pattern).
+- `package.json` — dependencies are governed by the skill's allowlist.
+  See the npm dependency policy in the skill.
+- `webpack.config.js` (if present) — bundler config.
+- `.eslintrc*`, `.prettierrc*` — toolchain configs.
+
+If you think you need to change a locked file, **stop and ask the user**
+with a one-paragraph explanation of why and what changes you want to
+make.
+
+## SDK pattern crib (~30 lines)
+
+### IVisual lifecycle
+
+```ts
+import powerbi from "powerbi-visuals-api";
+import IVisual = powerbi.extensibility.visual.IVisual;
+import VisualConstructorOptions = powerbi.extensibility.visual.VisualConstructorOptions;
+import VisualUpdateOptions = powerbi.extensibility.visual.VisualUpdateOptions;
+
+export class Visual implements IVisual {
+    private host: powerbi.extensibility.visual.IVisualHost;
+    private root: HTMLElement;
+
+    constructor(options: VisualConstructorOptions) {
+        this.host = options.host;
+        this.root = options.element;
+    }
+
+    public update(options: VisualUpdateOptions) {
+        const dv = options.dataViews?.[0];
+        if (!dv) return;            // no data yet
+        // render off dv.categorical or dv.matrix or dv.table
+    }
+}
+```
+
+### Reading categorical data
+
+```ts
+const cat = dv.categorical;
+if (!cat?.categories || !cat.values) return;
+const categoryValues = cat.categories[0].values; // x-axis labels
+const measureValues = cat.values[0].values;      // y-axis numbers
+```
+
+### Declaring data roles in `capabilities.json`
+
+```json
+{
+  "dataRoles": [
+    { "displayName": "Category", "name": "category", "kind": "Grouping" },
+    { "displayName": "Measure",  "name": "measure",  "kind": "Measure"  }
+  ],
+  "dataViewMappings": [{
+    "categorical": {
+      "categories": { "for": { "in": "category" } },
+      "values":     { "select": [{ "for": { "in": "measure" } }] }
+    }
+  }]
+}
+```
+
+`kind` matters: `Grouping` for axis/category fields, `Measure` for
+numeric values, `GroupingOrMeasure` only when truly ambiguous.
+
+### Formatting properties (modern formatting model)
+
+In `capabilities.json`:
+
+```json
+"objects": {
+  "barColor": {
+    "properties": {
+      "fill": { "type": { "fill": { "solid": { "color": true } } } }
+    }
+  }
+}
+```
+
+In `src/visual.ts` use the `formattingModel` API
+(`powerbi-visuals-utils-formattingmodel`) rather than the legacy
+`enumerateObjectInstances` — the legacy path is deprecated and will
+emit warnings on package.
+
+### Selection and tooltips
+
+Use `host.createSelectionIdBuilder()` per data point and
+`host.tooltipService` for tooltips. Don't roll your own DOM tooltips
+unless you have a strong reason; tooltips need to interact with the
+Power BI report context (drill-through, etc.).
+
+## Common gotchas
+
+- **`powerbi-visuals-api` major version mismatch** between the version
+  in `package.json` and the type imports → cryptic "type X is not
+  assignable to type Y" errors. Fix: align the `package.json` version
+  to the API your code targets.
+- **`enumerateObjectInstances` removed in v5+** → use the formatting
+  model API.
+- **Empty dataView on first `update()` call** → guard with
+  `if (!options.dataViews?.[0]) return;`. Power BI calls `update()`
+  before any data is bound.
+- **Numbers vs PrimitiveValue** → `cat.values[0].values` are
+  `PrimitiveValue[]` (string|number|boolean|Date|null). Cast or
+  narrow before doing math: `Number(v) || 0`.
+- **`update()` called on resize** → check `options.type` or just
+  re-render every time; visuals should be cheap to re-render.

--- a/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
@@ -101,10 +101,16 @@ plan step and iterate directly.
 Working directory: parent of the user's PBIR project (sibling, never
 inside `.Report` or `.pbip`).
 
+**Naming constraint:** `pbiviz new` rejects names containing anything
+other than letters and digits. No hyphens, no underscores, no dots.
+If the user's spec name has those (e.g. "my-gauge-visual"), strip them
+before scaffolding (e.g. `mygaugevisual`). The friendly displayName in
+`pbiviz.json` can still carry spaces and punctuation.
+
 ```bash
 # Inside <project-parent>/
-npx --yes powerbi-visuals-tools@^5.6.0 new <visual-name>
-cd <visual-name>
+npx --yes powerbi-visuals-tools@^5.6.0 new <visualname>
+cd <visualname>
 ```
 
 ### Auto-strip the circle-card demo
@@ -180,10 +186,10 @@ pbi-cli internal pbiviz-bump  # see note below
 
 # Package
 npx --yes powerbi-visuals-tools@^5.6.0 package
-# .pbiviz lands in dist/<visual-name>.<version>.pbiviz
+# .pbiviz lands in dist/<visualname>.<version>.pbiviz
 
 # Import into the user's report
-pbi visual import-custom dist/<visual-name>.<version>.pbiviz --replace
+pbi visual import-custom dist/<visualname>.<version>.pbiviz --replace
 ```
 
 **Version auto-bump.** Use the helper exposed via the skill (or call

--- a/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: Power BI Custom Visuals
+description: >
+  Vibe-code Power BI custom visuals end-to-end: scaffold a TypeScript project,
+  iterate on src/visual.ts and capabilities.json, validate with the Power BI
+  Visuals SDK toolchain, package to .pbiviz, and import into a PBIR report.
+  Invoke this skill whenever the user mentions "custom visual", "pbiviz",
+  "powerbi-visuals-tools", "IVisual", "build a chart Power BI doesn't have",
+  "developer visual", or wants a custom-built visual that the built-in
+  Power BI library can't render. NOT for: changing colors / themes
+  (use Power BI Themes), adding built-in visuals like bar/line/card/table
+  (use Power BI Visuals), or modifying the data model.
+tools: pbi-cli, Bash
+---
+
+# Power BI Custom Visuals Skill
+
+Build new Power BI custom visuals from natural language using the
+`powerbi-visuals-tools` SDK. Iteration is agent-driven on TypeScript
+compile errors; visual correctness is checked once at the end with the
+user.
+
+This skill produces a `.pbiviz` package and embeds it into a PBIR report
+via `pbi visual import-custom`. The TypeScript project lives **next to**
+the `.pbip` folder, never inside it.
+
+## Prerequisites
+
+The skill needs **Node.js** on PATH and the `powerbi-visuals-tools` npm
+package. Both are installed on first run with the user's consent; never
+silently.
+
+Pinned versions (override via env vars if needed):
+
+- `powerbi-visuals-tools@^5.6.0` (env: `PBIVIZ_VERSION`)
+- `powerbi-visuals-api@^5.11.0` (pinned in scaffolded `package.json`)
+
+The skill's edit patterns and AGENTS.md crib were written against these
+versions. Bump deliberately.
+
+### First-run prerequisite check
+
+```bash
+# 1. Probe Node
+node --version || true
+```
+
+If `node` is missing, **ask the user**:
+
+> Node.js isn't installed. Custom visual development needs it. Install
+> now? (yes/no)
+>
+> - Windows: `winget install OpenJS.NodeJS.LTS`
+> - macOS: `brew install node`
+> - Linux: use your package manager or nvm
+
+If user says yes, run the install command appropriate for their OS and
+re-probe. If user says no, stop the skill with a clear message.
+
+`pbiviz` itself runs through `npx --yes powerbi-visuals-tools@^5.6.0`,
+so there's no global install of the CLI itself. The first `npx`
+invocation will fetch and cache it locally.
+
+## Discovery: existing project vs fresh scaffold
+
+The skill's first action is always **discover**, not scaffold.
+
+1. Locate the user's PBIR project (the `.pbip` folder or its `.Report`
+   sibling).
+2. Look for sibling directories matching `*-visual/` containing a
+   `pbiviz.json`.
+3. Branch:
+   - **None found** → fresh scaffold flow (see "Plan-then-code" below).
+   - **One found** → load it; jump to edit-validate-package-import loop.
+   - **Multiple found** → ask the user which one; do not guess.
+
+This means re-invoking the skill on day 2 picks up where day 1 left off.
+
+## Plan-then-code (fresh scaffolds only)
+
+For fresh scaffolds, before touching any code:
+
+1. Read the user's natural-language spec.
+2. Output a **5-line plan** stating:
+   - Data roles needed (and which is `Grouping` vs `Measure`).
+   - Primary render approach (DOM, SVG, D3, canvas, charting lib).
+   - Formatting properties to expose in the right pane.
+   - npm dependencies beyond the scaffold defaults (justify each one;
+     see "npm dependency policy" below).
+3. **Wait for explicit user OK** before generating code.
+
+The plan exists to foreclose the most expensive failure mode: getting
+the data role declarations wrong in `capabilities.json` and discovering
+it 15 turns later. Skipping the plan is **not** an optimization.
+
+For sustained-authoring edits to an **existing** project, skip the
+plan step and iterate directly.
+
+## Scaffold
+
+Working directory: parent of the user's PBIR project (sibling, never
+inside `.Report` or `.pbip`).
+
+```bash
+# Inside <project-parent>/
+npx --yes powerbi-visuals-tools@^5.6.0 new <visual-name>
+cd <visual-name>
+```
+
+### Auto-strip the circle-card demo
+
+`pbiviz new` produces a working "circle card" demo. Strip it before
+handing off to iteration:
+
+1. Open `src/visual.ts`. The constructor and `update()` method contain
+   demo-specific code (creates an `<svg>` with a `<circle>` and `<text>`
+   that displays a number).
+2. Replace the `update()` body with a **single comment** like
+   `// TODO: build per spec` and remove the SVG/circle helpers.
+3. Open `capabilities.json`. Replace the demo's `dataRoles` (typically
+   `category` and `measure` for the circle demo) with the data roles
+   you planned. Empty the `objects` block; add formatting properties
+   per plan.
+4. Open `style/visual.less`. Empty it.
+5. Bump `apiVersion` in `pbiviz.json` and `powerbi-visuals-api` in
+   `package.json` to the pinned version above (only if the scaffold
+   doesn't already match).
+
+### Drop in AGENTS.md
+
+Write `AGENTS.md` at the project root using the template at
+`./AGENTS-template.md` (bundled alongside this `SKILL.md`). It tells
+future-Claude what's editable, what's locked, and gives 30 lines of
+SDK pattern crib. **Always drop this file.** It's the biggest single
+lever on first-iteration success.
+
+## Inner loop: agent-driven validation
+
+For each user-requested change:
+
+1. Edit the relevant files (see AGENTS.md for editable vs locked).
+2. Run **fast** type check:
+
+   ```bash
+   npx tsc --noEmit -p tsconfig.json
+   ```
+
+3. If errors:
+   - Read every error verbatim.
+   - Fix them.
+   - Re-run `tsc --noEmit`.
+   - Repeat **with progress discipline** (see "Failure cap" below).
+4. If clean: stop. Don't package every loop. Package only when the user
+   asks "show me" or you're at a natural completion point.
+
+Do **not** run `pbiviz start` in v1. The dev server's only purpose is
+sub-second hot-reload while a human watches Desktop, which is not how
+this loop works.
+
+### Failure cap (self-policed)
+
+To prevent infinite loops on cryptic SDK errors:
+
+- **5-turn no-progress cap.** "Progress" = error count strictly decreased
+  OR the qualitative root cause changed. After 5 turns with no progress,
+  **stop**.
+- **Oscillation detection.** If the same error appears, gets fixed, and
+  reappears within 3 turns, **stop**.
+- **On stop**: dump the current `tsc` output **verbatim** to the user
+  and offer two concrete hypotheses for the root cause. Ask the user to
+  guide. Do not silently keep trying.
+
+## Package and import
+
+When the inner loop is clean and you (or the user) are ready to see it:
+
+```bash
+# Bump patch version so Power BI Desktop's GUID+version cache invalidates
+pbi-cli internal pbiviz-bump  # see note below
+
+# Package
+npx --yes powerbi-visuals-tools@^5.6.0 package
+# .pbiviz lands in dist/<visual-name>.<version>.pbiviz
+
+# Import into the user's report
+pbi visual import-custom dist/<visual-name>.<version>.pbiviz --replace
+```
+
+**Version auto-bump.** Use the helper exposed via the skill (or call
+`pbiviz_bump_patch()` from `pbi_cli.core.custom_visual_backend`
+programmatically). It increments the patch number in `pbiviz.json`. If
+the user has set a non-`<int>.<int>.<int>` version manually, the bump
+is skipped and the manual value is respected.
+
+**Why the bump matters.** Power BI Desktop caches custom visuals by
+GUID + version. Repackaging without bumping risks Desktop serving stale
+code on next open. The bump is cheap insurance.
+
+If `pbiviz package` itself fails (capabilities schema invalid,
+unsupported API features, etc.), feed the error to Claude the same way
+as `tsc` errors. Subject to the same failure cap.
+
+## Eyeball handoff
+
+After a successful import, hand off to the user **once**:
+
+> Imported. Open the report in Power BI Desktop, place the visual on a
+> page, bind data, and tell me what looks wrong. I'll iterate from
+> there.
+
+If the user reports issues, repeat the inner loop (skip Plan since the
+project exists). If the user reports it looks right, you're done.
+
+## npm dependency policy
+
+Custom visuals routinely need libraries (D3, Lodash, charting libs).
+Installing arbitrary packages from npm is a real supply-chain concern
+under the user's identity, so this skill operates under an **allowlist**.
+
+### Allowlist (install without asking)
+
+Any package in this list, at or above the version floor, may be
+installed via `npm install <pkg>` (or `--save-dev`) without prior
+user confirmation:
+
+| Package                              | Floor       |
+|--------------------------------------|-------------|
+| `d3`                                 | `^7.0.0`    |
+| `d3-array`                           | `^3.0.0`    |
+| `d3-axis`                            | `^3.0.0`    |
+| `d3-color`                           | `^3.0.0`    |
+| `d3-format`                          | `^3.0.0`    |
+| `d3-interpolate`                     | `^3.0.0`    |
+| `d3-scale`                           | `^4.0.0`    |
+| `d3-selection`                       | `^3.0.0`    |
+| `d3-shape`                           | `^3.0.0`    |
+| `d3-time-format`                     | `^4.0.0`    |
+| `lodash`                             | `^4.17.0`   |
+| `date-fns`                           | `^3.0.0`    |
+| `powerbi-visuals-utils-formattingmodel` | `^6.0.0` |
+| `powerbi-visuals-utils-tooltiputils` | `^6.0.0`    |
+| `powerbi-visuals-utils-chartutils`   | `^6.0.0`    |
+| `powerbi-visuals-utils-dataviewutils`| `^6.0.0`    |
+| `@types/d3`                          | `^7.0.0`    |
+| `@types/lodash`                      | `^4.14.0`   |
+
+Type-only packages follow the same allowlist; there is no separate
+`devDependencies` rule.
+
+### Off-allowlist installs
+
+Any package **not** on the allowlist (including any version below a
+floor) requires **explicit user confirmation** before running
+`npm install`. State all four:
+
+1. **Package name** and exact version range.
+2. **Why** it's needed for the user's spec (specific feature, not
+   "it might be useful").
+3. **Bundle size impact estimate** (k or kk gzipped; check
+   bundlephobia.com if uncertain).
+4. **Alternative** considered (an allowlisted package or hand-rolled
+   code) and why it's worse.
+
+Then wait for explicit "yes" / "go ahead". Don't proceed on silence.
+
+This blocks the worst failure mode: hallucinating a typo'd package
+name (e.g. `d3-scaling`) and installing typosquat malware. Typos won't
+match the allowlist; the confirm step exposes them.
+
+## Concrete CLI surface used by this skill
+
+Provided by pbi-cli:
+
+- `pbi visual import-custom <pbiviz-file> [--replace] [--no-sync]`
+- `pbi visual list-custom`
+- `pbi visual remove-custom <guid-or-name> [--no-sync]`
+
+Provided by `npx --yes powerbi-visuals-tools@^5.6.0`:
+
+- `new <name>` — scaffold project
+- `package` — produce `.pbiviz` zip
+- `--create-cert` — generate dev cert (only needed on first
+  `package` invocation per machine; pbiviz prompts automatically)
+
+That's the entire toolchain. No other commands needed in v1.
+
+## What's deliberately out of scope (v1)
+
+- `pbiviz start` live preview server.
+- AppSource (public) custom visual registration via GUID-only
+  (separate `register-public` command, deferred).
+- Publishing to AppSource / Partner Center.
+- Multi-visual workspaces, monorepo patterns.
+- Custom visual themes / sharing across reports.
+
+If the user asks for any of the above, surface that it's outside v1
+scope and offer to file a follow-up.

--- a/tests/test_custom_visual_backend.py
+++ b/tests/test_custom_visual_backend.py
@@ -1,0 +1,371 @@
+"""Tests for pbi_cli.core.custom_visual_backend.
+
+Covers import-custom, list-custom, remove-custom on PBIR, plus the
+pbiviz.json patch-bump helper used by the power-bi-custom-visuals skill.
+
+Fixture .pbiviz files are built in-memory with ``zipfile`` rather than
+shelled out to ``pbiviz package`` so the unit suite stays Node-free.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pbi_cli.core.custom_visual_backend import (
+    custom_visual_import,
+    custom_visual_list,
+    custom_visual_remove,
+    pbiviz_bump_patch,
+)
+from pbi_cli.core.errors import PbiCliError
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_pbiviz(
+    path: Path,
+    *,
+    guid: str = "MyVisual1234ABCD",
+    name: str = "MyVisual",
+    display_name: str | None = None,
+    version: str = "1.0.0",
+    api_version: str = "5.11.0",
+    omit_package_json: bool = False,
+    bad_zip: bool = False,
+    bad_json: bool = False,
+    missing_visual_block: bool = False,
+    missing_guid: bool = False,
+) -> Path:
+    """Write a synthetic .pbiviz to *path* and return it.
+
+    Knobs let tests exercise validation paths without maintaining
+    multiple checked-in binary fixtures.
+    """
+    if bad_zip:
+        path.write_bytes(b"this is not a zip file")
+        return path
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        if not omit_package_json:
+            visual_block: dict[str, Any] = {}
+            if not missing_visual_block:
+                visual_block = {
+                    "name": name,
+                    "displayName": display_name or name,
+                    "version": version,
+                    "apiVersion": api_version,
+                }
+                if not missing_guid:
+                    visual_block["guid"] = guid
+            manifest: dict[str, Any] = {} if missing_visual_block else {"visual": visual_block}
+            payload = "this is not json" if bad_json else json.dumps(manifest)
+            zf.writestr("package.json", payload)
+        # Minimal resources file so the zip isn't suspiciously empty.
+        zf.writestr("resources/visual.js", "// stub")
+
+    path.write_bytes(buf.getvalue())
+    return path
+
+
+def _make_report(tmp_path: Path) -> Path:
+    """Build a tiny PBIR-shaped folder and return the *definition* path."""
+    report = tmp_path / "Demo.Report"
+    definition = report / "definition"
+    definition.mkdir(parents=True)
+    (definition / "report.json").write_text(
+        json.dumps({"layoutOptimization": "Disabled"}, indent=2),
+        encoding="utf-8",
+    )
+    return definition
+
+
+def _read_report_json(definition: Path) -> dict[str, Any]:
+    return json.loads((definition / "report.json").read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# import-custom
+# ---------------------------------------------------------------------------
+
+
+class TestImport:
+    def test_imports_a_valid_pbiviz(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "MyVisual.pbiviz")
+
+        result = custom_visual_import(defn, pbiviz, replace=False)
+
+        assert result["status"] == "added"
+        assert result["guid"] == "MyVisual1234ABCD"
+        assert result["version"] == "1.0.0"
+        assert result["replaced"] is False
+
+        # File landed in RegisteredResources/
+        resources = defn.parent / "StaticResources" / "RegisteredResources"
+        assert resources.is_dir()
+        landed = list(resources.glob("*.pbiviz"))
+        assert len(landed) == 1
+        assert "MyVisual1234ABCD" in landed[0].name
+
+        # report.json registered both the resource and the customVisual
+        rj = _read_report_json(defn)
+        assert rj["customVisuals"] == [{"name": "MyVisual1234ABCD", "version": "1.0.0"}]
+        pkg = next(p for p in rj["resourcePackages"] if p["name"] == "RegisteredResources")
+        assert any(i["type"] == 5 and "MyVisual1234ABCD" in i["name"] for i in pkg["items"])
+
+    def test_rejects_duplicate_without_replace(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "v1.pbiviz")
+        custom_visual_import(defn, pbiviz, replace=False)
+
+        # Second import with same GUID
+        pbiviz2 = _build_pbiviz(tmp_path / "v2.pbiviz", version="1.0.1")
+        with pytest.raises(PbiCliError, match="already registered"):
+            custom_visual_import(defn, pbiviz2, replace=False)
+
+    def test_replace_overwrites_in_place(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        custom_visual_import(defn, _build_pbiviz(tmp_path / "v1.pbiviz"), replace=False)
+        result = custom_visual_import(
+            defn,
+            _build_pbiviz(tmp_path / "v2.pbiviz", version="1.0.42"),
+            replace=True,
+        )
+
+        assert result["status"] == "added"
+        assert result["replaced"] is True
+        assert result["version"] == "1.0.42"
+
+        rj = _read_report_json(defn)
+        assert rj["customVisuals"] == [{"name": "MyVisual1234ABCD", "version": "1.0.42"}]
+        # No duplicate items in the resource package
+        pkg = next(p for p in rj["resourcePackages"] if p["name"] == "RegisteredResources")
+        custom_items = [i for i in pkg["items"] if i["type"] == 5]
+        assert len(custom_items) == 1
+
+    def test_missing_pbiviz_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        with pytest.raises(PbiCliError, match="not found"):
+            custom_visual_import(defn, tmp_path / "nope.pbiviz", replace=False)
+
+    def test_bad_zip_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "bad.pbiviz", bad_zip=True)
+        with pytest.raises(PbiCliError, match="not a valid zip"):
+            custom_visual_import(defn, pbiviz, replace=False)
+
+    def test_missing_package_json_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "no-manifest.pbiviz", omit_package_json=True)
+        with pytest.raises(PbiCliError, match="package.json not found"):
+            custom_visual_import(defn, pbiviz, replace=False)
+
+    def test_bad_json_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "badjson.pbiviz", bad_json=True)
+        with pytest.raises(PbiCliError, match="not valid JSON"):
+            custom_visual_import(defn, pbiviz, replace=False)
+
+    def test_missing_visual_block_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "noblock.pbiviz", missing_visual_block=True)
+        with pytest.raises(PbiCliError, match="missing 'visual'"):
+            custom_visual_import(defn, pbiviz, replace=False)
+
+    def test_missing_guid_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        pbiviz = _build_pbiviz(tmp_path / "noguid.pbiviz", missing_guid=True)
+        with pytest.raises(PbiCliError, match="visual.guid"):
+            custom_visual_import(defn, pbiviz, replace=False)
+
+    def test_no_report_json_raises(self, tmp_path: Path) -> None:
+        # Definition folder exists but report.json doesn't
+        report = tmp_path / "Demo.Report"
+        defn = report / "definition"
+        defn.mkdir(parents=True)
+        pbiviz = _build_pbiviz(tmp_path / "v.pbiviz")
+        with pytest.raises(PbiCliError, match="report.json not found"):
+            custom_visual_import(defn, pbiviz, replace=False)
+
+
+# ---------------------------------------------------------------------------
+# list-custom
+# ---------------------------------------------------------------------------
+
+
+class TestList:
+    def test_empty_report(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        result = custom_visual_list(defn)
+        assert result == {"embedded": [], "public": [], "total": 0}
+
+    def test_lists_embedded(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        custom_visual_import(defn, _build_pbiviz(tmp_path / "v.pbiviz"), replace=False)
+
+        result = custom_visual_list(defn)
+
+        assert result["total"] == 1
+        assert result["public"] == []
+        assert len(result["embedded"]) == 1
+        e = result["embedded"][0]
+        assert e["kind"] == "embedded"
+        assert e["guid"] == "MyVisual1234ABCD"
+        assert e["version"] == "1.0.0"
+        assert e["file"] is not None and e["file"].endswith(".pbiviz")
+
+    def test_lists_public_visuals(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        rj_path = defn / "report.json"
+        data = json.loads(rj_path.read_text(encoding="utf-8"))
+        data["publicCustomVisuals"] = ["PublicGuid1", "PublicGuid2"]
+        rj_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        result = custom_visual_list(defn)
+
+        assert result["total"] == 2
+        assert result["embedded"] == []
+        assert {p["guid"] for p in result["public"]} == {"PublicGuid1", "PublicGuid2"}
+        assert all(p["kind"] == "public" for p in result["public"])
+
+    def test_lists_mixed(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        custom_visual_import(defn, _build_pbiviz(tmp_path / "v.pbiviz"), replace=False)
+
+        rj_path = defn / "report.json"
+        data = json.loads(rj_path.read_text(encoding="utf-8"))
+        data["publicCustomVisuals"] = ["PublicGuid1"]
+        rj_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+        result = custom_visual_list(defn)
+        assert result["total"] == 2
+        assert len(result["embedded"]) == 1
+        assert len(result["public"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# remove-custom
+# ---------------------------------------------------------------------------
+
+
+class TestRemove:
+    def test_removes_by_guid(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        custom_visual_import(defn, _build_pbiviz(tmp_path / "v.pbiviz"), replace=False)
+
+        result = custom_visual_remove(defn, "MyVisual1234ABCD")
+
+        assert result["status"] == "removed"
+        assert result["guid"] == "MyVisual1234ABCD"
+        assert result["file_deleted"] is True
+
+        # File gone, registration gone
+        resources = defn.parent / "StaticResources" / "RegisteredResources"
+        assert list(resources.glob("*.pbiviz")) == []
+
+        rj = _read_report_json(defn)
+        assert rj.get("customVisuals", []) == []
+
+    def test_removes_by_name(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        custom_visual_import(
+            defn,
+            _build_pbiviz(tmp_path / "v.pbiviz", name="MyVisual"),
+            replace=False,
+        )
+
+        result = custom_visual_remove(defn, "MyVisual")
+
+        assert result["status"] == "removed"
+        assert result["guid"] == "MyVisual1234ABCD"
+
+    def test_ambiguous_name_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        custom_visual_import(
+            defn,
+            _build_pbiviz(tmp_path / "a.pbiviz", guid="GuidA1234567890", name="Same"),
+            replace=False,
+        )
+        custom_visual_import(
+            defn,
+            _build_pbiviz(tmp_path / "b.pbiviz", guid="GuidB1234567890", name="Same"),
+            replace=False,
+        )
+
+        with pytest.raises(PbiCliError, match="matches 2 custom visuals"):
+            custom_visual_remove(defn, "Same")
+
+    def test_unknown_identifier_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        with pytest.raises(PbiCliError, match="No embedded custom visual found"):
+            custom_visual_remove(defn, "NotARealGuid")
+
+    def test_empty_identifier_raises(self, tmp_path: Path) -> None:
+        defn = _make_report(tmp_path)
+        with pytest.raises(PbiCliError, match="required"):
+            custom_visual_remove(defn, "   ")
+
+
+# ---------------------------------------------------------------------------
+# pbiviz.json patch bump
+# ---------------------------------------------------------------------------
+
+
+class TestPatchBump:
+    def _write(self, path: Path, version: str) -> None:
+        path.write_text(
+            json.dumps({"visual": {"version": version}}, indent=2),
+            encoding="utf-8",
+        )
+
+    def test_bumps_clean_semver(self, tmp_path: Path) -> None:
+        pj = tmp_path / "pbiviz.json"
+        self._write(pj, "1.0.5")
+
+        result = pbiviz_bump_patch(pj)
+
+        assert result == {"status": "bumped", "previous": "1.0.5", "version": "1.0.6"}
+        data = json.loads(pj.read_text(encoding="utf-8"))
+        assert data["visual"]["version"] == "1.0.6"
+
+    def test_bumps_zero_patch(self, tmp_path: Path) -> None:
+        pj = tmp_path / "pbiviz.json"
+        self._write(pj, "0.1.0")
+        assert pbiviz_bump_patch(pj)["version"] == "0.1.1"
+
+    def test_skips_user_override_pattern(self, tmp_path: Path) -> None:
+        pj = tmp_path / "pbiviz.json"
+        self._write(pj, "1.0.0-rc.1")
+
+        result = pbiviz_bump_patch(pj)
+
+        assert result["status"] == "skipped"
+        assert "user override" in result["reason"]
+        # File untouched
+        data = json.loads(pj.read_text(encoding="utf-8"))
+        assert data["visual"]["version"] == "1.0.0-rc.1"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(PbiCliError, match="not found"):
+            pbiviz_bump_patch(tmp_path / "missing.json")
+
+    def test_missing_visual_block_raises(self, tmp_path: Path) -> None:
+        pj = tmp_path / "pbiviz.json"
+        pj.write_text(json.dumps({"other": "stuff"}), encoding="utf-8")
+        with pytest.raises(PbiCliError, match="missing 'visual'"):
+            pbiviz_bump_patch(pj)
+
+    def test_missing_version_raises(self, tmp_path: Path) -> None:
+        pj = tmp_path / "pbiviz.json"
+        pj.write_text(json.dumps({"visual": {"name": "x"}}), encoding="utf-8")
+        with pytest.raises(PbiCliError, match="visual.version"):
+            pbiviz_bump_patch(pj)


### PR DESCRIPTION
## Summary

- Ships a complete vibe-coding workflow for Power BI custom visuals: Claude skill drives `pbiviz new` → edit → `tsc --noEmit` → `pbiviz package` → import into PBIR.
- Three new `pbi visual` commands: `import-custom`, `list-custom`, `remove-custom`.
- New nightly + on-touch GitHub workflow runs the full Microsoft SDK toolchain end-to-end on Windows runners to catch SDK-version drift before users do.

### Skill: `power-bi-custom-visuals`

- **Toolchain**: auto-installs Node + `pbiviz` on first run with explicit user consent. `pbiviz` runs through `npx --yes` against pinned versions (`powerbi-visuals-tools@^5.6.0`, `powerbi-visuals-api@^5.11.0`). Override with `PBIVIZ_VERSION` env var.
- **Layout**: scaffolds the TypeScript project as a sibling of the `.pbip` folder, never inside PBIR. Clean boundary.
- **Plan-then-code on fresh scaffolds**: brief 5-line plan (data roles, render approach, formatting properties, deps) with explicit user OK before any code. Skipped for sustained-authoring edits to existing projects.
- **Inner loop**: agent-driven on `tsc --noEmit` — fast, deterministic, no human in the loop. 5-turn no-progress cap and oscillation detection prevent runaway iterations on cryptic SDK errors.
- **Auto-bump**: every `pbiviz package` increments the patch version in `pbiviz.json` so Power BI Desktop's GUID+version cache invalidates and serves fresh code. Manual user version overrides (e.g. `1.0.0-rc.1`) are respected.
- **npm allowlist**: D3 family, Lodash, date-fns, `powerbi-visuals-utils-*` install without confirmation. Off-list installs require Claude to justify name + version + reason + bundle impact and get explicit user OK. Blocks the typosquat attack vector.
- **AGENTS.md template** dropped into scaffolded projects: editable vs locked files + ~30 lines of SDK pattern crib (IVisual lifecycle, dataView reading, capabilities data roles, formatting model, common gotchas).

### CLI commands

| Command | Behavior |
|---|---|
| `pbi visual import-custom <pbiviz> [--replace] [--no-sync]` | Sanity-check zip + manifest, copy to `StaticResources/RegisteredResources/`, register in `report.json` (`customVisuals` + `resourcePackages`). `--replace` overwrites by GUID for the iteration loop. |
| `pbi visual list-custom` | List embedded and public (AppSource) custom visuals with a `kind` distinguisher. |
| `pbi visual remove-custom <guid-or-name>` | Deregister and physically delete the `.pbiviz`. GUID canonical; ambiguous names error with disambiguation guidance. |

### Out of scope (deferred follow-ups)

- `pbiviz start` live preview server.
- AppSource (public) registration via GUID-only.
- AppSource publish helper (`freeze-version`).
- Inspect-without-importing (`inspect-custom`).
- Bundled example visuals.

## Test plan

- [x] 25 new unit tests in [tests/test_custom_visual_backend.py](tests/test_custom_visual_backend.py) covering import (success / replace / duplicate-without-replace / bad zip / missing manifest / bad JSON / missing visual block / missing GUID / missing report.json), list (empty / embedded / public / mixed), remove (by GUID / by name / ambiguous name / unknown / empty), and version auto-bump (clean / zero patch / user override / missing file / missing visual block / missing version).
- [x] Synthetic in-memory `.pbiviz` fixtures built with `zipfile` — no Node required for unit tests.
- [x] Repo-wide `pytest`: 517 passed.
- [x] `ruff check`, `ruff format --check`, `mypy` all clean.
- [x] `pbi visual --help` confirms three new commands registered.
- [x] Skill discovery: `_get_bundled_skills()` picks up `power-bi-custom-visuals`.
- [ ] Node integration smoke (CI): runs nightly + on touch of the skill or pinned versions; checks `pbiviz new → tsc --noEmit → pbiviz package → pbi visual import-custom` end-to-end on `windows-latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)