### PR TITLE
ci: install pbiviz locally so webpack resolves ts-loader

### DIFF
--- a/.github/workflows/custom-visual-smoke.yml
+++ b/.github/workflows/custom-visual-smoke.yml
@@ -49,17 +49,26 @@ jobs:
           cd smoke
           npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" new smokevisual
 
-      - name: Type-check the scaffold
+      - name: Install deps (incl. local pbiviz so webpack loaders resolve)
         shell: bash
         working-directory: smoke/smokevisual
         run: |
           npm install --no-audit --no-fund
-          npx tsc --noEmit -p tsconfig.json
+          # pbiviz from the npx cache can't resolve ts-loader/webpack from the
+          # project's node_modules at package-time. Installing it locally
+          # brings the full loader chain into ./node_modules, so webpack
+          # resolves ts-loader the way pbiviz expects.
+          npm install --save-dev --no-audit --no-fund "powerbi-visuals-tools@${PBIVIZ_VERSION}"
+
+      - name: Type-check the scaffold
+        shell: bash
+        working-directory: smoke/smokevisual
+        run: npx tsc --noEmit -p tsconfig.json
 
       - name: Package the scaffold
         shell: bash
         working-directory: smoke/smokevisual
-        run: npx --yes "powerbi-visuals-tools@${PBIVIZ_VERSION}" package
+        run: ./node_modules/.bin/pbiviz package
 
       - name: Verify .pbiviz produced
         shell: bash

--- a/.github/workflows/custom-visual-smoke.yml
+++ b/.github/workflows/custom-visual-smoke.yml
@@ -60,6 +60,25 @@ jobs:
           # resolves ts-loader the way pbiviz expects.
           npm install --save-dev --no-audit --no-fund "powerbi-visuals-tools@${PBIVIZ_VERSION}"
 
+      - name: Fill required pbiviz.json metadata
+        shell: bash
+        working-directory: smoke/smokevisual
+        run: |
+          # pbiviz package strict-validates author/description/supportUrl.
+          # Scaffold leaves them blank; fill with smoke-test placeholders.
+          node -e '
+            const fs = require("fs");
+            const p = "pbiviz.json";
+            const j = JSON.parse(fs.readFileSync(p, "utf8"));
+            j.visual = j.visual || {};
+            j.visual.description = j.visual.description || "Smoke test custom visual";
+            j.visual.supportUrl = j.visual.supportUrl || "https://example.com";
+            j.author = j.author || {};
+            j.author.name = j.author.name || "pbi-cli smoke test";
+            j.author.email = j.author.email || "noreply@example.com";
+            fs.writeFileSync(p, JSON.stringify(j, null, 2));
+          '
+
       - name: Type-check the scaffold
         shell: bash
         working-directory: smoke/smokevisual


### PR DESCRIPTION
## Summary

Fixes the failing `Custom Visual SDK Smoke / pbiviz-end-to-end` job introduced in #4. The smoke test was failing at the package step with:

> Module not found: Error: Can't resolve 'ts-loader' in 'D:\a\pbi-cli\pbi-cli\smoke\smokevisual'

### Root cause

When `powerbi-visuals-tools` is invoked via `npx`, npx unpacks it to a cached location with its own `node_modules`. But pbiviz's bundled webpack config sets `resolveLoader` to look in the **project's** `node_modules` at package-time. So `ts-loader` and `webpack` lookups fail even though they exist in the npx cache, because the project doesn't have them.

### Fix

Install `powerbi-visuals-tools` as a local devDependency in the scaffolded project. This brings the full loader chain (ts-loader, webpack, etc.) into the project's `node_modules` where webpack expects to find them at package-time. Then call `./node_modules/.bin/pbiviz` directly instead of `npx`.

This matches the pattern Microsoft's own pbiviz docs recommend for CI.

## Test plan

- [ ] `pbiviz-end-to-end` job passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)