### PR TITLE
fix(skill): teach Claude to populate required pbiviz.json metadata

### DIFF
--- a/src/pbi_cli/skills/power-bi-custom-visuals/AGENTS-template.md
+++ b/src/pbi_cli/skills/power-bi-custom-visuals/AGENTS-template.md
@@ -18,13 +18,22 @@ scaffold. Keep it. Update it as the project evolves.
 🔒 **Don't touch without surfacing to the user first:**
 
 - `tsconfig.json` — TypeScript compiler config.
-- `pbiviz.json` — visual metadata (the skill auto-bumps `version` here;
-  don't edit `version` manually unless you mean to override the
-  auto-bump pattern).
 - `package.json` — dependencies are governed by the skill's allowlist.
   See the npm dependency policy in the skill.
 - `webpack.config.js` (if present) — bundler config.
 - `.eslintrc*`, `.prettierrc*` — toolchain configs.
+
+⚠️ **`pbiviz.json` — partial:**
+
+- `visual.version` is **auto-bumped** by the skill on every package.
+  Don't edit it manually unless you mean to override the auto-bump
+  pattern (e.g. set `1.0.0-rc.1` to freeze for a release candidate).
+- `visual.description`, `visual.supportUrl`, `author.name`,
+  `author.email` are **user-editable**. The skill populates placeholder
+  values at scaffold time (`pbiviz package` requires them); the user
+  replaces with real values before AppSource publish.
+- Other fields (`apiVersion`, `style`, `capabilities`) are pinned by
+  the scaffold; treat as locked.
 
 If you think you need to change a locked file, **stop and ask the user**
 with a one-paragraph explanation of why and what changes you want to

--- a/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
+++ b/src/pbi_cli/skills/power-bi-custom-visuals/SKILL.md
@@ -132,6 +132,25 @@ handing off to iteration:
    `package.json` to the pinned version above (only if the scaffold
    doesn't already match).
 
+### Fill required `pbiviz.json` metadata
+
+`pbiviz package` strict-validates four fields and **fails to build**
+if any are missing. The scaffold leaves them blank, so populate them
+before any package step or you'll waste iteration turns chasing a
+"not specified" error that has nothing to do with the code:
+
+| Field                 | Source                                         |
+|-----------------------|------------------------------------------------|
+| `visual.description`  | One-line summary derived from the user's spec  |
+| `visual.supportUrl`   | `"https://example.com"` placeholder (real URL needed for AppSource publish) |
+| `author.name`         | `git config user.name` (run it; fall back to `"pbi-cli user"` if empty) |
+| `author.email`        | `git config user.email` (run it; fall back to `"noreply@example.com"` if empty) |
+
+Do this immediately after auto-stripping the circle-card demo, **once**,
+in a single edit to `pbiviz.json`. If the user later wants to publish to
+AppSource, they replace these values themselves; the skill's auto-bump
+on `version` doesn't touch any other field, so user edits stick.
+
 ### Drop in AGENTS.md
 
 Write `AGENTS.md` at the project root using the template at


### PR DESCRIPTION
## Summary

Carries the lesson from PR #5's CI fix back into the skill itself so users hit the same failure mode CI did.

### Problem

`pbiviz package` strict-validates four metadata fields and fails to build if any are missing:

- \`author.name\`
- \`author.email\`
- \`visual.description\`
- \`visual.supportUrl\`

The \`pbiviz new\` scaffold leaves them blank. Without this fix, the first time a real user runs the skill end-to-end:

1. Claude scaffolds, strips circle-card, iterates on \`tsc --noEmit\` — all green.
2. Claude runs \`pbiviz package\` to hand off for eyeball check.
3. Package fails with \"Author name is not specified\" etc.
4. Claude tries to fix in the source code (the wrong place), burns the 5-turn no-progress cap, escalates to user.

CI hit exactly this in PR #4. CI got patched in PR #5 with inline Node injection. **The skill itself was still broken** — that's what this fixes.

### Fix

- **SKILL.md**: New \"Fill required pbiviz.json metadata\" step right after the circle-card auto-strip. Sources author defaults from \`git config user.name\` / \`user.email\` (no extra prompt to the user); description derived from the spec Claude already has from plan-then-code; supportUrl placeholder \`https://example.com\` with a note that it must be a real URL before AppSource publish.
- **AGENTS-template.md**: \`pbiviz.json\` is no longer flatly \"don't touch.\" Carved into three buckets: auto-bumped \`version\` (skill-managed, hands off), user-editable metadata (author/description/supportUrl — populate at scaffold, user can replace later), and locked structural fields (\`apiVersion\`, \`style\`, \`capabilities\`).

## Test plan

- [x] No code changes; SKILL.md and AGENTS.md template only.
- [x] Existing unit tests still pass (no Python touched).
- [ ] First end-to-end user run on a fresh machine no longer hits the metadata error during package step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)