### PR TITLE
ci: fix Custom Visual SDK Smoke tsc failure (@types/node drift)

### DIFF
--- a/.github/workflows/custom-visual-smoke.yml
+++ b/.github/workflows/custom-visual-smoke.yml
@@ -59,6 +59,15 @@ jobs:
           # brings the full loader chain into ./node_modules, so webpack
           # resolves ts-loader the way pbiviz expects.
           npm install --save-dev --no-audit --no-fund "powerbi-visuals-tools@${PBIVIZ_VERSION}"
+          # The scaffold doesn't pin @types/node, so a transitive install
+          # pulls the latest major (>=22.7 / 24.x). Those defs reference
+          # IteratorObject / AsyncIteratorObject / BuiltinIteratorReturn,
+          # which require a newer TypeScript than the scaffold bundles -- so
+          # `tsc --noEmit` fails with "Cannot find name 'BuiltinIteratorReturn'"
+          # and the Readable/Duplex/Dir stream mismatches. Pin @types/node to
+          # the line matching this job's Node runtime (20) so the type-check
+          # is stable. Bump this together with node-version above.
+          npm install --save-dev --no-audit --no-fund "@types/node@^20"
 
       - name: Fill required pbiviz.json metadata
         shell: bash


### PR DESCRIPTION
## What was failing

The nightly **Custom Visual SDK Smoke** workflow (`pbiviz-end-to-end`) failed at the `npx tsc --noEmit` step with errors like:

- `Cannot find name 'BuiltinIteratorReturn'`
- `Cannot find name 'AsyncIteratorObject'` / `Cannot find name 'IteratorObject'`
- `Class 'Duplex' incorrectly implements interface 'ReadWriteStream'`
- `Property '[Symbol.asyncIterator]' in type 'Readable' is not assignable ...`
- `Property '[Symbol.asyncIterator]' in type 'Dir' is not assignable ...`

## Root cause

The `powerbi-visuals-tools` scaffold does **not** pin `@types/node`. So `npm install` resolved it to the latest major (`>=22.7` / `24.x`). Those type definitions reference `IteratorObject`, `AsyncIteratorObject`, and `BuiltinIteratorReturn`, which only exist in newer TypeScript lib definitions than the version the scaffold bundles. The result is `tsc --noEmit` failing with the errors above — sending a failure email every night.

This is transitive dependency drift, not `powerbi-visuals-tools` / `powerbi-visuals-api` drift, so the right fix is to stabilize the type definitions rather than bump the SDK pins.

## Fix

Pin `@types/node` to the line matching the job's Node runtime (Node 20) in the deps-install step, with a comment to bump it alongside `node-version`. This keeps the type-check stable regardless of the TypeScript version the scaffold ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SPeNsh6vHsVyMkwdatuGiq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Windows smoke-test workflow to ensure compatibility with the Node 20 runtime, preventing build failures during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->